### PR TITLE
Update style guide for MARKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,8 +1043,8 @@ func myFunction() {
 
 * **4.2.1** Always leave a space after `//`.
 * **4.2.2** Always leave comments on their own line.
-* **4.2.3** When using `// MARK: - whatever`, leave a newline after the comment.
-* **4.2.4** Use `// MARK: - whatever` for type definitions
+* **4.2.3** When using `// MARK: - whatever`, leave a empty line before and after the comment.
+* **4.2.4** Use `// MARK: - whatever` for type definitions (excluding nested types)
 * **4.2.4** Use `// MARK: whatever` for extensions and code seperation
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,7 @@ func myFunction() {
 * **4.2.2** Always leave comments on their own line.
 * **4.2.3** When using `// MARK: - whatever`, leave a empty line before and after the comment.
 * **4.2.4** Use `// MARK: - whatever` for type definitions (excluding nested types)
-* **4.2.4** Use `// MARK: whatever` for extensions and code seperation
+* **4.2.4** Use `// MARK: whatever` for nested type definitions, extensions, and code seperation.
 
 ```swift
 


### PR DESCRIPTION
Use "MARK:" instead of "MARK: -" for nested types. This removes the divider line in mini map. Requested by @yootsubo